### PR TITLE
Change NoAmountSpecifiedError to function

### DIFF
--- a/src/currencyEngineXMR.js
+++ b/src/currencyEngineXMR.js
@@ -761,7 +761,7 @@ class MoneroEngine {
     }
 
     if (bns.eq(nativeAmount, '0')) {
-      throw (new Error('ErrorNoAmountSpecified'))
+      throw (new error.NoAmountSpecifiedError())
     }
 
     if (bns.gte(nativeAmount, this.walletLocalData.totalBalances.XMR)) {


### PR DESCRIPTION
The purpose of this task is to have the Monero plugin throw the new `noAmountSpecifiedError` rather than a regular error with a string, and therefore let the GUI catch the error and hide it when the user first goes to the `SendConfirmation` scene  

https://app.asana.com/0/361770107085503/736453047132716/f

Connected PR's:
https://github.com/Airbitz/edge-currency-ripple/pull/4
https://github.com/Airbitz/edge-react-gui/pull/715
https://github.com/Airbitz/edge-core-js/pull/103